### PR TITLE
fixed image rendering issue

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,5 +1,6 @@
 <div align="center">
-  <img src="images/logo.png" alt="OER-Forge Logo" width="120" />
+  <!-- <img src="images/logo.png" alt="OER-Forge Logo" width="120" /> -->
+  ![OER-Forge LOGO](images/logo.png)
   
   # OER-Forge
   

--- a/oerforge/convert.py
+++ b/oerforge/convert.py
@@ -179,7 +179,10 @@ def convert_md_to_docx(src_path, out_path, record_id=None, conn=None):
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     try:
         import subprocess
-        subprocess.run(["pandoc", src_path, "-o", out_path], check=True)
+        # Set resource path to the directory containing the source file and the build directory
+        resource_paths = [os.path.dirname(src_path), BUILD_ROOT, os.path.join(BUILD_ROOT, 'images')]
+        resource_path_arg = "--resource-path=" + ":".join(resource_paths)
+        subprocess.run(["pandoc", src_path, "-o", out_path, resource_path_arg], check=True)
         logging.info(f"[DOCX] Converted {src_path} to {out_path}")
         # Insert converted file record into files table
         if conn is not None:
@@ -229,7 +232,10 @@ def convert_md_to_pdf(src_path, out_path, record_id=None, conn=None):
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     try:
         import subprocess
-        subprocess.run(["pandoc", src_path, "-o", out_path], check=True)
+        # Set resource path to the directory containing the source file and the build directory
+        resource_paths = [os.path.dirname(src_path), BUILD_ROOT, os.path.join(BUILD_ROOT, 'images')]
+        resource_path_arg = "--resource-path=" + ":".join(resource_paths)
+        subprocess.run(["pandoc", src_path, "-o", out_path, resource_path_arg], check=True)
         logging.info(f"[PDF] Converted {src_path} to {out_path}")
         # Insert converted file record into files table
         if conn is not None:
@@ -278,7 +284,10 @@ def convert_md_to_tex(src_path, out_path, record_id=None, conn=None):
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     try:
         import subprocess
-        subprocess.run(["pandoc", src_path, "-o", out_path], check=True)
+        # Set resource path to the directory containing the source file and the build directory
+        resource_paths = [os.path.dirname(src_path), BUILD_ROOT, os.path.join(BUILD_ROOT, 'images')]
+        resource_path_arg = "--resource-path=" + ":".join(resource_paths)
+        subprocess.run(["pandoc", src_path, "-o", out_path, resource_path_arg], check=True)
         logging.info(f"[TEX] Converted {src_path} to {out_path}")
         # Insert converted file record into files table
         if conn is not None:


### PR DESCRIPTION
Images were not rendering on single file creation because

- it was not using the correct relative import

images were not creating on batch creation because
- needed to add --resource-path argument for pandoc
- pandoc doesn't do well for mixing html and markdown, os it needed to switch to using the markdwon for creating images

this should fix that issue and make images render now.

didn't build any tests because yolo.

this should fix #6 